### PR TITLE
tutsplus article uses 'books' as a fields on AuthorSerializer which woul...

### DIFF
--- a/app/bookreview/models.py
+++ b/app/bookreview/models.py
@@ -22,7 +22,7 @@ class Book(models.Model):
     objects = BookManager()
     title = models.CharField(max_length=200)
     isbn = models.CharField(max_length=20)
-    author = models.ForeignKey(Author, related_name='authors')
+    author = models.ForeignKey(Author, related_name='books')
 
     def __unicode__(self):
         return self.title


### PR DESCRIPTION
...d

lead to error if related_name is 'authors'. So, related_name should be
'books'.
